### PR TITLE
add support for the :monitor operative

### DIFF
--- a/Octo.YAML-tmLanguage
+++ b/Octo.YAML-tmLanguage
@@ -50,6 +50,10 @@ patterns:
   name: support.function.octo
   match: (?<=^|\s)(?:\:breakpoint)(?=$|\s)
 
+- comment: Memory monitor command
+  name: support.function.octo
+  match: (?<=^|\s)(?:\:monitor)(?=$|\s)
+
 - comment: Deprecated commands
   name: invalid.deprecated.octo
   match: (?<=^|\s)(\:proto)(?=$|\s)

--- a/Octo.tmLanguage
+++ b/Octo.tmLanguage
@@ -100,6 +100,14 @@
 		</dict>
 		<dict>
 			<key>comment</key>
+			<string>Memory monitor command</string>
+			<key>match</key>
+			<string>(?&lt;=^|\s)(?:\:monitor)(?=$|\s)</string>
+			<key>name</key>
+			<string>support.function.octo</string>
+		</dict>
+		<dict>
+			<key>comment</key>
 			<string>Deprecated commands</string>
 			<key>match</key>
 			<string>(?&lt;=^|\s)(\:proto)(?=$|\s)</string>


### PR DESCRIPTION
The `:monitor` operative is a (relatively) new out-of-band debugging feature which sets up a memory monitor. From the manual:

> The command :monitor, followed by a base address and length, will register a memory monitor. While your program runs, monitors will be updated continuously to reflect the contents of memory. Pressing "m" will toggle the memory monitor on and off. Like :breakpoint, :monitor is out-of-band and generates no instructions.