### PR TITLE
Support for string literals, :stringmode, and :assert

### DIFF
--- a/Octo.tmLanguage
+++ b/Octo.tmLanguage
@@ -86,7 +86,7 @@
 			<key>comment</key>
 			<string>Metaprogramming commands</string>
 			<key>match</key>
-			<string>(?&lt;=^|\s)(?:\:macro|\:calc|\:byte)(?=$|\s)</string>
+			<string>(?&lt;=^|\s)(?:\:macro|\:calc|\:byte|\:stringmode)(?=$|\s)</string>
 			<key>name</key>
 			<string>support.function.octo</string>
 		</dict>
@@ -95,6 +95,14 @@
 			<string>Breakpoint command</string>
 			<key>match</key>
 			<string>(?&lt;=^|\s)(?:\:breakpoint)(?=$|\s)</string>
+			<key>name</key>
+			<string>support.function.octo</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Assertion command</string>
+			<key>match</key>
+			<string>(?&lt;=^|\s)(?:\:assert)(?=$|\s)</string>
 			<key>name</key>
 			<string>support.function.octo</string>
 		</dict>
@@ -169,6 +177,25 @@
 			<string>(?&lt;=^|\s):\s+\S+(?=$|\s)</string>
 			<key>name</key>
 			<string>entity.name.function.octo</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>String Literals</string>
+			<key>begin</key>
+			<string>"</string>
+			<key>end</key>
+			<string>"</string>
+			<key>name</key>
+			<string>string.quoted.double.octo</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\\[tnrv0\\"]</string>
+					<key>name</key>
+					<string>constant.character.escape.octo</string>
+				</dict>
+			</array>
 		</dict>
 	</array>
 	<key>scopeName</key>


### PR DESCRIPTION
The latest Octo release adds several new features, which I have reflected here:

- Double-quoted c-like string literals (`"foo\n bar"`), for use with `:stringmode`
- `:stringmode`, which is used to define a special kind of macro which is applied in turn to each character of a string literal. (See [the manual](https://github.com/JohnEarnest/Octo/blob/gh-pages/docs/Manual.md#strings))
- `:assert`, which is used to check and enforce compile-time invariants.

I've updated the XML version of the language definition and tested it locally. I find YAML, especially its behavior regarding escapes, totally baffling, and as far as I can tell that file is redundant. Is there a reason for having two parallel copies of the language definitions?