### PR TITLE
add support for :pointer

### DIFF
--- a/Octo.YAML-tmLanguage
+++ b/Octo.YAML-tmLanguage
@@ -44,7 +44,7 @@ patterns:
 
 - comment: Metaprogramming commands
   name: support.function.octo
-  match: (?<=^|\s)(?:\:macro|\:calc|\:byte|\:stringmode)(?=$|\s)
+  match: (?<=^|\s)(?:\:macro|\:calc|\:byte|\:pointer|\:stringmode)(?=$|\s)
 
 - comment: Breakpoint command
   name: support.function.octo

--- a/Octo.tmLanguage
+++ b/Octo.tmLanguage
@@ -86,7 +86,7 @@
 			<key>comment</key>
 			<string>Metaprogramming commands</string>
 			<key>match</key>
-			<string>(?&lt;=^|\s)(?:\:macro|\:calc|\:byte|\:stringmode)(?=$|\s)</string>
+			<string>(?&lt;=^|\s)(?:\:macro|\:calc|\:byte|\:pointer|\:stringmode)(?=$|\s)</string>
 			<key>name</key>
 			<string>support.function.octo</string>
 		</dict>

--- a/Octo.tmLanguage
+++ b/Octo.tmLanguage
@@ -86,7 +86,7 @@
 			<key>comment</key>
 			<string>Metaprogramming commands</string>
 			<key>match</key>
-			<string>(?&lt;=^|\s)(?:\:macro|\:calc|\:byte)(?=$|\s)</string>
+			<string>(?&lt;=^|\s)(?:\:macro|\:calc|\:byte|\:stringmode)(?=$|\s)</string>
 			<key>name</key>
 			<string>support.function.octo</string>
 		</dict>
@@ -95,6 +95,14 @@
 			<string>Breakpoint command</string>
 			<key>match</key>
 			<string>(?&lt;=^|\s)(?:\:breakpoint)(?=$|\s)</string>
+			<key>name</key>
+			<string>support.function.octo</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Assertion command</string>
+			<key>match</key>
+			<string>(?&lt;=^|\s)(?:\:assert)(?=$|\s)</string>
 			<key>name</key>
 			<string>support.function.octo</string>
 		</dict>
@@ -169,6 +177,25 @@
 			<string>(?&lt;=^|\s):\s+\S+(?=$|\s)</string>
 			<key>name</key>
 			<string>entity.name.function.octo</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>String Literals</string>
+			<key>begin</key>
+			<string>"</string>
+			<key>end</key>
+			<string>"</string>
+			<key>name</key>
+			<string>string.quoted.double.octo</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\\[tnrv0\\"]</string>
+					<key>name</key>
+					<string>constant.character.escape.octo</string>
+				</dict>
+			</array>
 		</dict>
 	</array>
 	<key>scopeName</key>


### PR DESCRIPTION
I introduced a new statement and keyword for working with 16-bit addresses, `:pointer`. From the reference manual:


> XO-Chip programming often requires working with 16-bit pointers. If forward-referencing of labels is required, use `:pointer`. This directive assembles as two sequential bytes:
> 
> ```
> : label-a
> ...
> :pointer label-a
> :pointer label-b
> ...
> : label-b
> ```
