### PR TITLE
Update keyword list to reflect the 'pitch := vx' instruction

### DIFF
--- a/Octo.YAML-tmLanguage
+++ b/Octo.YAML-tmLanguage
@@ -64,7 +64,7 @@ patterns:
 
 - comment: Statement keywords (standard)
   name: keyword.other.octo
-  match: (?<=^|\s)(?:clear|bcd|save|load|sprite|hex|random|delay|key|-key|buzzer|native)(?=$|\s)
+  match: (?<=^|\s)(?:clear|bcd|save|load|sprite|hex|random|delay|pitch|key|-key|buzzer|native)(?=$|\s)
 
 - comment: Statement keywords (SCHIP)
   name: keyword.other.octo

--- a/Octo.tmLanguage
+++ b/Octo.tmLanguage
@@ -126,7 +126,7 @@
 			<key>comment</key>
 			<string>Statement keywords (standard)</string>
 			<key>match</key>
-			<string>(?&lt;=^|\s)(?:clear|bcd|save|load|sprite|hex|random|delay|key|-key|buzzer|native)(?=$|\s)</string>
+			<string>(?&lt;=^|\s)(?:clear|bcd|save|load|sprite|hex|random|delay|pitch|key|-key|buzzer|native)(?=$|\s)</string>
 			<key>name</key>
 			<string>keyword.other.octo</string>
 		</dict>


### PR DESCRIPTION
This instruction was added in the [XO-Chip 1.1 spec](https://github.com/JohnEarnest/Octo/blob/gh-pages/docs/XO-ChipSpecification.md#audio), giving programmers more control over audio output.